### PR TITLE
Add Android Auto support to notifications

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -29,6 +29,10 @@
         android:label="@string/app_name"
         android:theme="@style/ConversationsTheme"
         tools:replace="android:label">
+
+        <meta-data android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+
         <service android:name=".services.XmppConnectionService" />
 
         <receiver android:name=".services.EventReceiver">

--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -13,6 +13,7 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationCompat.BigPictureStyle;
 import android.support.v4.app.NotificationCompat.Builder;
 import android.support.v4.app.NotificationManagerCompat;
+import android.support.v4.app.NotificationCompat.CarExtender.UnreadConversation;
 import android.support.v4.app.RemoteInput;
 import android.support.v4.content.ContextCompat;
 import android.text.SpannableString;
@@ -337,6 +338,7 @@ public class NotificationService {
 		final Builder mBuilder = new NotificationCompat.Builder(mXmppConnectionService);
 		if (messages.size() >= 1) {
 			final Conversation conversation = messages.get(0).getConversation();
+			final UnreadConversation.Builder mUnreadBuilder = new UnreadConversation.Builder(conversation.getName());
 			mBuilder.setLargeIcon(mXmppConnectionService.getAvatarService()
 					.get(conversation, getPixel(64)));
 			mBuilder.setContentTitle(conversation.getName());
@@ -346,14 +348,17 @@ public class NotificationService {
 			} else {
 				Message message;
 				if ((message = getImage(messages)) != null) {
-					modifyForImage(mBuilder, message, messages);
+					modifyForImage(mBuilder, mUnreadBuilder, message, messages);
 				} else {
-					modifyForTextOnly(mBuilder, messages);
+					modifyForTextOnly(mBuilder, mUnreadBuilder, messages);
 				}
 				RemoteInput remoteInput = new RemoteInput.Builder("text_reply").setLabel(UIHelper.getMessageHint(mXmppConnectionService, conversation)).build();
 				NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(R.drawable.ic_send_text_offline, "Reply", createReplyIntent(conversation, false)).addRemoteInput(remoteInput).build();
 				NotificationCompat.Action wearReplyAction = new NotificationCompat.Action.Builder(R.drawable.ic_send_text_offline, "Reply", createReplyIntent(conversation, true)).addRemoteInput(remoteInput).build();
 				mBuilder.extend(new NotificationCompat.WearableExtender().addAction(wearReplyAction));
+				mUnreadBuilder.setReplyAction(createReplyIntent(conversation, true), remoteInput);
+				mUnreadBuilder.setReadPendingIntent(createReadPendingIntent(conversation));
+				mBuilder.extend(new NotificationCompat.CarExtender().setUnreadConversation(mUnreadBuilder.build()));
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 					mBuilder.addAction(replyAction);
 				}
@@ -387,8 +392,8 @@ public class NotificationService {
 		return mBuilder;
 	}
 
-	private void modifyForImage(final Builder builder, final Message message,
-								final ArrayList<Message> messages) {
+	private void modifyForImage(final Builder builder, final UnreadConversation.Builder uBuilder,
+								final Message message, final ArrayList<Message> messages) {
 		try {
 			final Bitmap bitmap = mXmppConnectionService.getFileBackend()
 					.getThumbnail(message, getPixel(288), false);
@@ -412,11 +417,11 @@ public class NotificationService {
 			}
 			builder.setStyle(bigPictureStyle);
 		} catch (final FileNotFoundException e) {
-			modifyForTextOnly(builder, messages);
+			modifyForTextOnly(builder, uBuilder, messages);
 		}
 	}
 
-	private void modifyForTextOnly(final Builder builder, final ArrayList<Message> messages) {
+	private void modifyForTextOnly(final Builder builder, final UnreadConversation.Builder uBuilder, final ArrayList<Message> messages) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 			NotificationCompat.MessagingStyle messagingStyle = new NotificationCompat.MessagingStyle(mXmppConnectionService.getString(R.string.me));
 			Conversation conversation = messages.get(0).getConversation();
@@ -426,6 +431,8 @@ public class NotificationService {
 			for (Message message : messages) {
 				String sender = message.getStatus() == Message.STATUS_RECEIVED ? UIHelper.getMessageDisplayName(message) : null;
 				messagingStyle.addMessage(UIHelper.getMessagePreview(mXmppConnectionService,message).first, message.getTimeSent(), sender);
+				uBuilder.addMessage(UIHelper.getMessagePreview(mXmppConnectionService,message).first);
+				uBuilder.setLatestTimestamp(message.getTimeSent());
 			}
 			builder.setStyle(messagingStyle);
 		} else {
@@ -553,6 +560,14 @@ public class NotificationService {
 		intent.putExtra("dismiss_notification",dismissAfterReply);
 		int id =  conversation.getUuid().hashCode() % (dismissAfterReply ? 402359 : 426583);
 		return PendingIntent.getService(mXmppConnectionService, id, intent, 0);
+	}
+
+	private PendingIntent createReadPendingIntent(Conversation conversation) {
+		final Intent intent = new Intent(mXmppConnectionService, XmppConnectionService.class);
+		intent.setAction(XmppConnectionService.ACTION_MARK_AS_READ);
+		intent.putExtra("uuid", conversation.getUuid());
+		intent.setPackage(mXmppConnectionService.getPackageName());
+		return PendingIntent.getService(mXmppConnectionService, conversation.getUuid().hashCode() % 247527, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 	}
 
 	private PendingIntent createDisableForeground() {

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -148,6 +148,7 @@ public class XmppConnectionService extends Service {
 	}
 
 	public static final String ACTION_REPLY_TO_CONVERSATION = "reply_to_conversations";
+	public static final String ACTION_MARK_AS_READ = "mark_as_read";
 	public static final String ACTION_CLEAR_NOTIFICATION = "clear_notification";
 	public static final String ACTION_DISABLE_FOREGROUND = "disable_foreground";
 	public static final String ACTION_DISMISS_ERROR_NOTIFICATIONS = "dismiss_error";
@@ -672,6 +673,9 @@ public class XmppConnectionService extends Service {
 							directReply(c, body.toString(),intent.getBooleanExtra("dismiss_notification",false));
 						}
 					}
+					break;
+				case ACTION_MARK_AS_READ:
+					markRead(c, true);
 					break;
 				case AudioManager.RINGER_MODE_CHANGED_ACTION:
 					if (xaOnSilentMode()) {

--- a/src/main/res/xml/automotive_app_desc.xml
+++ b/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="notification"/>
+</automotiveApp>


### PR DESCRIPTION
This patch adds required additions in order to show notifications
in Android Auto. Messages are read aloud and voice reply is
offered. The functionaliy has been tested with the Android Auto
standalone app as well as with the DHU simulator as describes
here:

https://developer.android.com/training/auto/testing/index.html